### PR TITLE
Feature: Add swift version as paramether to swift.sh

### DIFF
--- a/swift.sh
+++ b/swift.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+#
+#  Version can be selected by 'source swift.sh [5.10|6.1]' or '. swift.sh [5.10|6.1]'
+#  The default version is 5.10. If version is missing, default is used
+#
+
+swiftVersion="${1:-'5.10'}"
 SWVersion=$(lsb_release -rs)
 
-wget http://packages.semaphoreci.com/swift/swift-5.10-RELEASE-ubuntu${SWVersion}.tar.gz -O /tmp/swift-5.10-RELEASE-ubuntu${SWVersion}.tar.gz
+wget http://packages.semaphoreci.com/swift/swift-${swiftVersion}-RELEASE-ubuntu${SWVersion}.tar.gz -O /tmp/swift-${swiftVersion}-RELEASE-ubuntu${SWVersion}.tar.gz
 cd /tmp/
-tar -zxf swift-5.10-RELEASE-ubuntu${SWVersion}.tar.gz
-sudo mv /tmp/swift-5.10-RELEASE-ubuntu${SWVersion} /opt/swift
+tar -zxf swift-${swiftVersion}-RELEASE-ubuntu${SWVersion}.tar.gz
+sudo mv /tmp/swift-${swiftVersion}-RELEASE-ubuntu${SWVersion} /opt/swift
 echo "export PATH=/opt/swift/usr/bin:$PATH" >> ~/.bashrc 
 source ~/.bashrc
 swift --version


### PR DESCRIPTION
Swift.sh was changed to accept a version parameter.
It now accepts `source swift.sh [5.10|6.1]`.
`source swift.sh` still works, it installs default `5.10`.
